### PR TITLE
Fix für #26: Intern jetzt 4 Nachkommastellen 

### DIFF
--- a/documentation/dokuwiki/data/pages/anforderungen.txt
+++ b/documentation/dokuwiki/data/pages/anforderungen.txt
@@ -3,7 +3,7 @@
 Damit Part-DB einwandfrei läuft, müssen folgende Kriterien erfüllt sein:
 
   * Webserver mit mindestens 15MB Platz (mit Footprint-Bilder mindestens 60MB)
-  * **PHP >= 5.3.0** mit [[http://php.net/manual/de/book.pdo.php|PDO]] inkl. [[http://www.php.net/manual/de/ref.pdo-mysql.php|MySQL Plugin]]
+  * **PHP >= 5.3.0** mit [[http://php.net/manual/de/book.pdo.php|PDO]] inkl. [[http://www.php.net/manual/de/ref.pdo-mysql.php|MySQL Plugin]] und [[http://php.net/manual/de/book.mbstring.php|mbstring]]
   * MySQL Datenbank mit der Speicherengine InnoDB (MariaDB wurde auch schon erfolgreich getestet)
   * Webbrowser mit JavaScript und HTML4 Unterstützung.
 

--- a/documentation/dokuwiki/data/pages/installation.txt
+++ b/documentation/dokuwiki/data/pages/installation.txt
@@ -36,8 +36,8 @@ Dann lädt man Part-DB herunter und entpackt das Archiv in das Verzeichnis des W
 </note>
 
 <code>
-wget -O part-db.tar.gz https://github.com/sandboxgangster/Part-DB/releases/download/v0.3.0/Part-DB_0.3.0.tar.gz
-sudo tar xzf part-db.tar.gz -C /var/www
+wget -O part-db.tar.gz https://github.com/sandboxgangster/Part-DB/releases/download/v0.3.1/Part-DB_0.3.1.tar.gz
+sudo tar -xzf part-db.tar.gz -C /var/www
 </code>
 
 Hat man keinen direkten Zugriff (z.B. über SSH) auf den Server, muss man die Dateien per FTP auf den Server hochladen. Dazu lädt man das Archiv auf dem persönlichen Computer herunter, entpackt es und kopiert die entpackten Dateien dann per FTP-Client (z.B. FileZilla) auf den Server.

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -41,6 +41,7 @@
         2013-05-18  kami89          - added functions "set_admin_password()" and "is_admin_password()"
         2013-05-26  kami89          - moved function "check_requirements()" to "lib.start_session.php"
         2013-09-09  kami89          - replaced "get_svn_revision()" with "get_git_branch_name()" and "get_git_commit_hash()"
+        2015-05-11  susnux          - modified "float_to_money_string()" to show up to 5 decimal places
 */
 
     /**
@@ -464,21 +465,40 @@
         if ($number === NULL)
             return '-';
 
-        settype($number, 'float');
+       // settype($number, 'float');
 
         global $config;
 
         if (strlen($language) == 0)
             $language = $config['language'];
 
-        // get the money format from config(_defaults).php
-        $format = isset($config['money_format'][$language]) ? $config['money_format'][$language] : (($language == $config['language']) ? '%.3n' : '%.3i');
-
         if ($language != $config['language'])
         {
             // change locale, because the $language is not the default language!
             if ( ! own_setlocale(LC_MONETARY, $language))
                 debug('error', 'Sprache "'.$language.'" kann nicht gesetzt werden!', __FILE__, __LINE__, __METHOD__);
+        }
+
+        // get the money format from config(_defaults).php
+        if (isset($config['money_format'][$language]) ) {
+            $format = $config['money_format'][$language];
+        } else {
+            // not set in config, so generate it
+            $locale = localeconv();
+            // number of digits used in current language
+            $local_digits = $locale['int_frac_digits'];
+            // digits of the number
+            $number_digits = ( (int) $number != $number ) ? (strlen($number) - strpos($number,  $locale['decimal_point'])) - 1 : 0;
+
+            // international or local format?
+            $format_type = ($language == $config['language']) ? 'n' : 'i';
+
+            if ($number_digits > $local_digits) {
+                $n = $number_digits > 5 ? 5 : $number_digits;
+                $format = "%." . $n . $format_type;
+            } else {
+                $format = '%' . $format_type;
+            }
         }
 
         $result = trim(money_format($format, $number));

--- a/lib/lib.php
+++ b/lib/lib.php
@@ -472,7 +472,7 @@
             $language = $config['language'];
 
         // get the money format from config(_defaults).php
-        $format = isset($config['money_format'][$language]) ? $config['money_format'][$language] : (($language == $config['language']) ? '%n' : '%i');
+        $format = isset($config['money_format'][$language]) ? $config['money_format'][$language] : (($language == $config['language']) ? '%.3n' : '%.3i');
 
         if ($language != $config['language'])
         {

--- a/updates/db_update_steps.php
+++ b/updates/db_update_steps.php
@@ -32,6 +32,7 @@
         2013-05-20  kami89              - added "case 13" (change attachements file path from "/media/" to "/data/media/")
         2013-05-24  kami89              - added "case 14" (BUGFIX: set parts.id_master_picture_attachement where it is NULL)
         2014-05-12  kami89              - added "case 15" (new feature: automatic links to products on the suppliers/manufacturers website)
+        2015-05-10  susnux              - added "case 16" (intern part price is stored with 4 decimal places)
 */
 
     /*
@@ -45,7 +46,7 @@
      *          -> this new "case" must have the number "LATEST_DB_VERSION - 1"!
      */
 
-    define('LATEST_DB_VERSION', 16);  // <-- increment here
+    define('LATEST_DB_VERSION', 17);  // <-- increment here
 
     /*
      * Get update steps
@@ -2375,7 +2376,12 @@
             $updateSteps[] = "ALTER TABLE `orderdetails` ADD `supplier_product_url` TINYTEXT NOT NULL AFTER `obsolete`";
             break;
 
-          /*case 16:
+          case 16:
+            //Price is now stored with 4 decimal places (8 or 9 digits are the same amout of bytes in the db, so I choose 9)
+            $updateSteps[] = "ALTER TABLE `pricedetails` MODIFY `price` DECIMAL(9,4)";
+            break;
+
+          /*case 17:
             // create table "users"
             $updateSteps[] = "CREATE TABLE `users` (".
                 // Benutzerinformationen

--- a/updates/db_update_steps.php
+++ b/updates/db_update_steps.php
@@ -2377,8 +2377,8 @@
             break;
 
           case 16:
-            //Price is now stored with 4 decimal places (8 or 9 digits are the same amout of bytes in the db, so I choose 9)
-            $updateSteps[] = "ALTER TABLE `pricedetails` MODIFY `price` DECIMAL(9,4)";
+            //Price is now stored with 5 decimal places.
+            $updateSteps[] = "ALTER TABLE `pricedetails` MODIFY `price` DECIMAL(9,5)";
             break;
 
           /*case 17:


### PR DESCRIPTION
Intern wird hiermit dann mit 4 Nachkommastellen gearbeitet ( #26) und als default werden 3 angezeigt (ich denke ein guter Kompromiss, 4 brauchen die meisten nicht immer und könnten die Lesbarkeit verringern, 2 hingegen rundet zu stark, 3 scheint ganz gut).
Außer dem habe ich in der Doku den Link auf 0.3.1 angepasst.