### PR TITLE
Fix für #27: Datenbankupdate farbig darstellen (den Log)

### DIFF
--- a/lib/class.Database.php
+++ b/lib/class.Database.php
@@ -34,6 +34,7 @@
                                         - rollback()
                                         - example how to use it
         2013-02-03  kami89          - the update process will now memorize the position if an error occurs
+        2015-05-11  susnux          - updated update() function to distinguish between error and normal message
 */
 
     include_once(BASE.'/updates/db_update_steps.php');

--- a/system_database.php
+++ b/system_database.php
@@ -137,13 +137,16 @@
 
                 $database_update_executed = true;
                 $update_log = $database->update();
-                $messages[] = array('text' => nl2br($update_log), 'color' => 'red');
+                foreach ($update_log as $message) {
+                    $messages[] = array('text' => nl2br($message['text']), 'color' => ($message['error'] == true ? 'red' : 'black'));
+                }
             }
             catch (Exception $e)
             {
                 $messages[] = array('text' => 'Es trat ein Fehler auf!', 'strong' => true, 'color' => 'red');
                 $messages[] = array('text' => 'Fehlermeldung: '.nl2br($e->getMessage()), 'color' => 'red');
             }
+            $messages[count($messages)-1]['text'] .= nl2br("\n");
             break;
     }
 

--- a/system_database.php
+++ b/system_database.php
@@ -28,6 +28,7 @@
         [DATE]      [NICKNAME]          [CHANGES]
         2012-??-??  weinbauer73         - changed to templates
         2012-09-14  kami89              - changed to OOP
+        2015-05-11  susnux              - updated db update log
 */
 
     include_once('start_session.php');


### PR DESCRIPTION
Wie in #27 geschrieben kann der rote Log ziemlich einschüchternd sein ;-)
Hiermit werden dann nur Fehler rot dargestellt der Rest schwarz (grün wäre vielleicht für einige Menschen mit Rot-Grün-Sehschwäche nicht so ideal).
Im Grunde habe ich die vorhandenen Funktionen genutzt, nur der update log in der Datenbank-Klasse war nicht besonders gut geeignet für die vorhandenen "color"-Funktionen in system_database.php.