### PR TITLE
Allow git branch names with /

### DIFF
--- a/lib/lib.php
+++ b/lib/lib.php
@@ -77,7 +77,7 @@
         if (file_exists(BASE.'/.git/HEAD'))
         {
             $git = File(BASE.'/.git/HEAD');
-            $head = explode("/", $git[0]);
+            $head = explode("/", $git[0], 3);
             $branch = trim($head[2]);
             return $branch;
         }


### PR DESCRIPTION
Ein `/` ist auch in Branchnamen erlaubt. Damit dieser richtig ausgewertet wird, darf der Inhalt von
.git/HEAD nur in 3 Teile aufgeteilt werden. Die ersten beiden Teile sind `refs` und `heads` und müssen entfernt werden. Alles dahinter in der Name vom Branch.