### PR TITLE
Add .gitattributes to avoid automatic EOL conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Disable automatic end-of-line conversion for all files (same as "core.autocrlf=false").
+* -text


### PR DESCRIPTION
My experience with Git shows that Git's `core.autocrlf` feature introduces pain for sure, so we should completely disable it. Developers should use editors/IDEs which use LF line endings instead.